### PR TITLE
Moved chromedriver.exe to maven dependency WebdriverManager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,9 +18,13 @@
 *.zip
 *.tar.gz
 *.rar
+target/
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 .idea/
 images/
 target/generated-test-sources/
+
+# IntelliJ files
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,11 @@
       <artifactId>junit-jupiter-engine</artifactId>
       <version>5.4.0</version>
     </dependency>
+    <dependency>
+      <groupId>io.github.bonigarcia</groupId>
+      <artifactId>webdrivermanager</artifactId>
+      <version>3.7.1</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/ing/DriverFactory.java
+++ b/src/main/java/com/ing/DriverFactory.java
@@ -1,5 +1,6 @@
 package com.ing;
 
+import io.github.bonigarcia.wdm.WebDriverManager;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
@@ -23,7 +24,7 @@ public class DriverFactory {
 
     public static WebDriver getDriver() {
         if (driver == null) {
-            System.setProperty("webdriver.chrome.driver", "/Users/mbruno/Katas/chromedriver");
+            WebDriverManager.chromedriver().version("77.0.3865.40").setup();
             driver = new ChromeDriver(getOptions());
         }
         return driver;


### PR DESCRIPTION
Changed hardcoded `ChromeDriver.exe` path by `WebDriverManager.chromedriver()` and added `WebDriverManager` to maven dependencies.